### PR TITLE
add basic A/B experiment

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,16 +1,28 @@
+import os
+import time
+import requests
+import random
 from flask import Flask, request, jsonify, Response
 from flasgger import Swagger
 from flask_cors import CORS
-import requests
-import os
-import time
 from lib_version.version_util import VersionUtil
 
 app = Flask(__name__)
 CORS(app)
 swagger = Swagger(app)
 
-MODEL_SERVICE_URL = os.getenv("MODEL_SERVICE_URL")
+MODEL_SERVICE_URL_A = os.getenv("MODEL_SERVICE_URL_A")
+MODEL_SERVICE_URL_B = os.getenv("MODEL_SERVICE_URL_B")
+A_B_RATE = float(os.getenv("A_B_RATE", '0.5'))
+
+
+def get_model_service_url():
+    if random.random > A_B_RATE:
+        return MODEL_SERVICE_URL_A
+
+    return MODEL_SERVICE_URL_B
+
+
 failed_predictions = 0
 predictions = 0
 last_req_time = 0
@@ -124,7 +136,7 @@ def predict():
     input_data = request.get_json()
     try:
         start = time.time()
-        response = requests.post(f"{MODEL_SERVICE_URL}/predict", json=input_data)
+        response = requests.post(f"{get_model_service_url()}/predict", json=input_data)
         end = time.time()
         
         predictions += 1
@@ -180,38 +192,45 @@ def submit():
 
 @app.route('/metrics', methods=['GET'])
 def metrics():
-  global predictions, last_req_time, failed_predictions, correct_pred, wrong_pred
+    global predictions, last_req_time, failed_predictions, correct_pred, wrong_pred
 
-  # Predictions
-  # This can be used as a template the add more metrics
-  m = "# HELP predictions This is a counter keeping track of the total amount of predictions made.\n"
-  m+= "# TYPE predictions counter\n" # counter | gauge
-  m+= f"predictions {predictions} \n"
+    # Predictions
+    # This can be used as a template the add more metrics
+    m = "# HELP predictions This is a counter keeping track of the total \
+      amount of predictions made.\n"
+    m += "# TYPE predictions counter\n" # counter | gauge
+    m += f"predictions {predictions} \n"
 
-  m+= "# HELP failed_predictions This is a counter keeping track of the total amount of failed predictions attempts caused by techincal errors.\n"
-  m+= "# TYPE failed_predictions counter\n"
-  m+= f"failed_predictions {failed_predictions}\n"
+    m += "# HELP failed_predictions This is a counter keeping track of the \
+    total amount of failed predictions attempts caused by techincal errors.\n"
+    m += "# TYPE failed_predictions counter\n"
+    m += f"failed_predictions {failed_predictions}\n"
 
-  m+= "# HELP correct_pred This is a counter keeping track of the total amount of correct predictions.\n"
-  m+= "# TYPE correct_pred counter\n"
-  m+= f"correct_pred {correct_pred}\n"
+    m += "# HELP correct_pred This is a counter keeping track of the total \
+    amount of correct predictions.\n"
+    m += "# TYPE correct_pred counter\n"
+    m += f"correct_pred {correct_pred}\n"
 
-  m+= "# HELP wrong_pred This is a counter keeping track of the total amount of wrong predictions.\n"
-  m+= "# TYPE wrong_pred counter\n"
-  m+= f"wrong_pred {wrong_pred}\n"
+    m += "# HELP wrong_pred This is a counter keeping track of the total \
+    amount of wrong predictions.\n"
+    m += "# TYPE wrong_pred counter\n"
+    m += f"wrong_pred {wrong_pred}\n"
 
-  # TODO decide how exactly we want to track this (i.e. last req time or avg req time)
-  m+= "# HELP last_req_time This is a gauge measuring the amount of time it took the last request to complete.\n"
-  m+= "# TYPE last_req_time gauge\n"
-  m+= f"last_req_time {last_req_time}\n"
-  
-  m+= "# HELP accuracy This is a gauge measuring the accuracy of the model.\n"
-  m+= "# TYPE accuracy gauge\n"
+    # TODO decide how exactly we want to track this (i.e. last req time
+    # or avg req time)
+    m += "# HELP last_req_time This is a gauge measuring the amount of time it\
+     took the last request to complete.\n"
+    m += "# TYPE last_req_time gauge\n"
+    m += f"last_req_time {last_req_time}\n"
 
-  total = max(correct_pred + wrong_pred, 1)
-  m+= f"accuracy {correct_pred / total}\n"
+    m += "# HELP accuracy This is a gauge measuring the accuracy \
+    of the model.\n"
+    m += "# TYPE accuracy gauge\n"
 
-  return Response(m, mimetype="text/plain")  
+    total = max(correct_pred + wrong_pred, 1)
+    m += f"accuracy {correct_pred / total}\n"
+
+    return Response(m, mimetype="text/plain")  
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=8080, debug=True)


### PR DESCRIPTION
# Description
This is part of the changes necessary to enable the continuous experiment part of assignment 5. The goal is to monitor the prediction metrics (as previously defined) for a Gaussian and Bernouli Naive Bayes classifier. The added `get_model_service_url()` function returns URL A (Gaussian) or B (Bernouli) randomly with probability 0.5, which can be overridden using environment variables. 

With these changes, all we have to do to enable the experiment is provide the relevant URLs.

# Changes
- linting
- add basic A/B gateway function.

# TODO 
I have not been able to test this (correctly) yet, as I keep running into issues getting all of the dashboards to boot correctly. 